### PR TITLE
use libmamba as solver

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -28,8 +28,10 @@ function run() {
         yield exec.exec("bash", [installerLocation, "-b", "-p", home.concat("/miniconda")]);
         core.addPath(home.concat("/miniconda/bin"));
         yield exec.exec(home.concat("/miniconda/bin/conda"), ["config", "--set", "always_yes", "yes"]);
+        // Install conda-libmamba-solver
+        yield exec.exec(home.concat("/miniconda/bin/conda"), ["install", "conda-libmamba-solver"]);
         // Strictly speaking, only the galaxy tests need planemo and samtools
-        yield exec.exec(home.concat("/miniconda/bin/conda"), ["create", "-n", "foo", "-q", "--yes", "-c", "conda-forge", "-c", "bioconda", "python=3.7", "numpy", "scipy", "matplotlib==3.1.1", "nose", "flake8", "plotly", "pysam", "pyBigWig", "py2bit", "deeptoolsintervals", "planemo", "samtools"]);
+        yield exec.exec(home.concat("/miniconda/bin/conda"), ["create", "-n", "foo", "-q", "--yes", "-c", "conda-forge", "-c", "bioconda", "--experimental-solver", "libmamba", "python=3.7", "numpy", "scipy", "matplotlib==3.1.1", "nose", "flake8", "plotly", "pysam", "pyBigWig", "py2bit", "deeptoolsintervals", "planemo", "samtools"]);
         // Caching should end here
         // Install deepTools
         yield exec.exec(home.concat("/miniconda/envs/foo/bin/python"), ["-m", "pip", "install", ".", "--no-deps", "--ignore-installed", "-vv"]);

--- a/lib/src/main.js
+++ b/lib/src/main.js
@@ -28,8 +28,10 @@ function run() {
         yield exec.exec("bash", [installerLocation, "-b", "-p", home.concat("/miniconda")]);
         core.addPath(home.concat("/miniconda/bin"));
         yield exec.exec(home.concat("/miniconda/bin/conda"), ["config", "--set", "always_yes", "yes"]);
+        // Install conda-libmamba-solver
+        yield exec.exec(home.concat("/miniconda/bin/conda"), ["install", "conda-libmamba-solver"]);
         // Strictly speaking, only the galaxy tests need planemo and samtools
-        yield exec.exec(home.concat("/miniconda/bin/conda"), ["create", "-n", "foo", "-q", "--yes", "-c", "conda-forge", "-c", "bioconda", "python=3.7", "numpy", "scipy", "matplotlib==3.1.1", "nose", "flake8", "plotly", "pysam", "pyBigWig", "py2bit", "deeptoolsintervals", "planemo", "samtools"]);
+        yield exec.exec(home.concat("/miniconda/bin/conda"), ["create", "-n", "foo", "-q", "--yes", "-c", "conda-forge", "-c", "bioconda", "--experimental-solver", "libmamba", "python=3.7", "numpy", "scipy", "matplotlib==3.1.1", "nose", "flake8", "plotly", "pysam", "pyBigWig", "py2bit", "deeptoolsintervals", "planemo", "samtools"]);
         // Caching should end here
         // Install deepTools
         yield exec.exec(home.concat("/miniconda/envs/foo/bin/python"), ["-m", "pip", "install", ".", "--no-deps", "--ignore-installed", "-vv"]);

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,8 +24,9 @@ async function run() {
 
     await exec.exec(home.concat("/miniconda/bin/conda"), ["config", "--set", "always_yes", "yes"]);
 
+    await exec.exec(home.concat("/miniconda/bin/conda"), ["install", "conda-libmamba-solver"]);
     // Strictly speaking, only the galaxy tests need planemo and samtools
-    await exec.exec(home.concat("/miniconda/bin/conda"), ["create", "-n", "foo", "-q", "--yes", "-c", "conda-forge", "-c", "bioconda", "python=3.7", "numpy", "scipy", "matplotlib==3.1.1", "nose", "flake8", "plotly", "pysam", "pyBigWig", "py2bit", "deeptoolsintervals", "planemo", "samtools"]);
+    await exec.exec(home.concat("/miniconda/bin/conda"), ["create", "-n", "foo", "-q", "--yes", "-c", "conda-forge", "-c", "bioconda", "--experimental-solver", "libmamba", "python=3.7", "numpy", "scipy", "matplotlib==3.1.1", "nose", "flake8", "plotly", "pysam", "pyBigWig", "py2bit", "deeptoolsintervals", "planemo", "samtools"]);
 
     // Caching should end here
 


### PR DESCRIPTION
Creating the conda environment on linux takes ages:
https://github.com/deeptools/deepTools/actions/workflows/test.yml
For example:
![image](https://user-images.githubusercontent.com/30404086/196900471-3c292b5e-a9ef-4e4d-bf0f-a39c462a1bbc.png)

Usually 1 or 2 hours.
I propose to use libmamba to speed up.
I tried here:
https://github.com/lldelisle/deepTools/actions/workflows/test.yml
And it took 3 minutes.

However, I don't know anything about github-actions. I deduced I should modify the 3 files but maybe I needed to modify something else.