### PR TITLE
Node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: "Setup Conda"
 description: "Setup Conda"
 runs:
-  using: "node12"
+  using: "node16"
   main: "lib/main.js"

--- a/lib/main.js
+++ b/lib/main.js
@@ -34,7 +34,7 @@ function run() {
         // Install conda-libmamba-solver
         yield exec.exec(home.concat("/miniconda/bin/conda"), ["install", "conda-libmamba-solver"]);
         // Strictly speaking, only the galaxy tests need planemo and samtools
-        yield exec.exec(home.concat("/miniconda/bin/conda"), ["create", "-n", "foo", "-q", "--yes", "-c", "conda-forge", "-c", "bioconda", "--experimental-solver", "libmamba", "python=3.7", "numpy", "scipy", "matplotlib==3.1.1", "nose", "flake8", "plotly", "pysam", "pyBigWig", "py2bit", "deeptoolsintervals", "planemo", "samtools"]);
+        yield exec.exec(home.concat("/miniconda/bin/conda"), ["create", "-n", "foo", "-q", "--yes", "-c", "conda-forge", "-c", "bioconda", "--experimental-solver", "libmamba", "python=3.7", "numpy", "scipy", "matplotlib==3.1.1", "nose", "flake8", "plotly", "pysam", "pyBigWig", "py2bit", "deeptoolsintervals", "allure-python-commons==2.12.0", "planemo", "samtools"]);
         // Caching should end here
         // Install deepTools
         yield exec.exec(home.concat("/miniconda/envs/foo/bin/python"), ["-m", "pip", "install", ".", "--no-deps", "--ignore-installed", "-vv"]);

--- a/lib/main.js
+++ b/lib/main.js
@@ -25,7 +25,10 @@ function run() {
         // Otherwise conda can't install for some reason
         yield io.mkdirP(home.concat('/.conda'));
         const installerLocation = yield tc.downloadTool(URL);
-        yield exec.exec("bash", [installerLocation, "-b", "-p", home.concat("/miniconda")]);
+        // It seems conda installer needs the file to end with .sh
+        // tc.downloadTool yields a hashed file without that ending, so we rename.
+        yield exec.exec("mv", [installerLocation, home.concat("/mc.sh")]);
+        yield exec.exec("bash", [home.concat("/mc.sh"), "-b", "-p", home.concat("/miniconda")]);
         core.addPath(home.concat("/miniconda/bin"));
         yield exec.exec(home.concat("/miniconda/bin/conda"), ["config", "--set", "always_yes", "yes"]);
         // Install conda-libmamba-solver

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "node12-template-action",
+  "name": "typescript-action",
   "version": "0.0.0",
   "private": true,
-  "description": "Node 12 template action",
+  "description": "Node 16 template action",
   "main": "lib/main.js",
   "scripts": {
     "build": "tsc",
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/actions/javascript-template.git"
+    "url": "git+https://github.com/actions/typescript-action.git"
   },
   "keywords": [
     "actions",
@@ -20,17 +20,17 @@
   "author": "GitHub",
   "license": "MIT",
   "dependencies": {
-    "@actions/core": "^1.2.6",
-    "@actions/exec": "^1.0.1",
-    "@actions/tool-cache": "^1.1.1",
+    "@actions/core": "^1.10.0",
+    "@actions/exec": "^1.1.1",
+    "@actions/tool-cache": "^2.0.1",
     "bioconda_utils_setup_conda": "file:bioconda_utils_setup_conda"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.13",
-    "@types/node": "^12.7.4",
-    "jest": "^24.8.0",
-    "jest-circus": "^24.7.1",
-    "ts-jest": "^24.0.2",
-    "typescript": "^3.5.1"
+    "@types/jest": "^29.4.1",
+    "@types/node": "^18.15.3",
+    "jest": "^29.5.0",
+    "jest-circus": "^29.5.0",
+    "ts-jest": "^29.0.5",
+    "typescript": "^4.9.5"
   }
 }


### PR DESCRIPTION
- boost from node12 to node16
- latest allure-python-commons breaks planemo. Hardcap to 2.12.0
- conda installer fails if the installer itself lacks '.sh' ending. Since downloadTool yields a file with a hashed filename, I included a mv to include the suffix
- boosted some dependency minimal versions

actions are passing now:
https://github.com/WardDeb/deepTools/actions/runs/4425389748
